### PR TITLE
Fix deprecation regarding missing babel reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "express": "^4.8.5",
     "glob": "^4.0.5"
   },
+  "dependencies" : {
+        "ember-cli-babel": "^6.6.0"        
+  },
   "keywords": [
     "ember-addon",
     "slider",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "glob": "^4.0.5"
   },
   "dependencies" : {
-        "ember-cli-babel": "^6.6.0"        
+    "ember-cli-babel": "^6.6.0"        
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
DEPRECATION: Addon files were detected in `C:/Users/Bent/Documents/Projekter/VisAftale3copy/VisAftale3copy/node_modules/ember-cli-range-input/addon`, but no JavaScript preprocessors were found for `ember-cli-range-input`. Please make sure to add a preprocessor (most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in `ember-cli-range-input`'s `package.json`.